### PR TITLE
Various fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ update the pose and velocity until the mismatch is minimized.
 
 The software was originally developed and tested against **[ROS Kinetic
 Kame](http://wiki.ros.org/kinetic)** and **Ubuntu 16.04 (Xenial Xerus)**. It also runs on **[ROS
-Melodic Morenia](http://wiki.ros.org/melodic)** with **Ubuntu 18.04 (Bionic Beaver)**.
+Melodic Morenia](http://wiki.ros.org/melodic)** with **Ubuntu 18.04 (Bionic Beaver)** and
+**[ROS Noetic Ninjemys](wiki.ros.org/noetic)** with **Ubuntu 20.04 (Focal Fossa)**.
 
 Install [catkin tools](http://catkin-tools.readthedocs.org/en/latest/installing.html) and [vcstool](https://github.com/dirk-thomas/vcstool) if needed:
 
@@ -116,8 +117,9 @@ They are all available through the package management of Ubuntu and can be insta
 
 All the software is contained in a ROS package and can be built and run using catkin:
 
+    cd .. # should be in catkin_ws now
     catkin build direct_event_camera_tracker
-    source catkin_ws/devel/setup.bash
+    source devel/setup.bash
 
 To launch it, you need a running roscore. So in one terminal run
 
@@ -387,8 +389,20 @@ Clicking on the plot will select that pose.
 ### 6.5 Troubleshooting
 
  - Keep an eye on the console for warnings etc.
+
  - *ERROR: Failed to read depth from framebuffer.*
    Make sure your graphics drivers are working. This might not be the case when running inside a VM.
+
+ - "WARNING: Mesh has no textures associated!" For the atrium.obj model this can be ignored. It
+   contains multiple meshes, one of which does not have textures.
+
+ - *QOpenGLShader: Unable to open file "opengl/shaders/cloud_color.vert"
+   QOpenGLShader: Unable to open file "opengl/shaders/cloud_color.frag"
+   QOpenGLShaderProgram::uniformLocation(MVP): shader program is not linked
+   QOpenGLShaderProgram::uniformLocation(camera_pos): shader program is not linked*
+   The application needs shaders to render the map. It looks for these files in current working
+   directory, so you have to execute `roscd direct_event_camera_tracker` to change the working
+   directory to the application directory.
 
 <a name="scripts"></a>
 ## 7. Scripts

--- a/direct_event_camera_tracker/CMakeLists.txt
+++ b/direct_event_camera_tracker/CMakeLists.txt
@@ -18,6 +18,7 @@ set(SOURCES
     gui/StateTable.cpp
     gui/render_jacobi_tester.cpp
     gui/general_jacobi_tester.cpp
+    gui/se3_pose_editor.cpp
     gui/evo_map_publisher.cpp
     utils/ceres.cpp
     opengl/world_renderer.cpp
@@ -71,6 +72,8 @@ find_package(Boost REQUIRED)
 #set(sophus_DIR "/usr/local/share/sophus/cmake/")
 #find_package(sophus REQUIRED)
 find_package(QCustomPlot REQUIRED)
+
+set(OpenGL_GL_PREFERENCE "LEGACY")
 find_package(OpenGL REQUIRED)
 find_package(PCL 1.7 REQUIRED)
 

--- a/direct_event_camera_tracker/gui/ImageLabel.cpp
+++ b/direct_event_camera_tracker/gui/ImageLabel.cpp
@@ -74,7 +74,7 @@ void ImageLabel::setPixmap(cv::Mat mat, bool apply_colormap, bool normalize)
     } else if (mat.type() == CV_8UC3) {
 
         // Qt expects RGB, but OpenCV uses BGR
-        cv::cvtColor(mat, mat, CV_BGR2RGB);
+        cv::cvtColor(mat, mat, cv::COLOR_BGR2RGB);
 
         setPixmap(QPixmap::fromImage(QImage(
                         mat.data, mat.cols, mat.rows, mat.step, QImage::Format_RGB888)));

--- a/direct_event_camera_tracker/gui/maingui.cpp
+++ b/direct_event_camera_tracker/gui/maingui.cpp
@@ -18,6 +18,8 @@ MainGUI::MainGUI(const YAML::Node& config)
     plot_matrix(new PlotMatrix(*this)),
     last_published_pose_marker_id(0)
 {
+    std::cout << "Eigen Version: " << EIGEN_WORLD_VERSION << "." << EIGEN_MAJOR_VERSION << "." << EIGEN_MINOR_VERSION << std::endl;
+
     ui.setupUi(this);
 
     ui.opt_param_pane->setFloating(true);
@@ -138,6 +140,7 @@ MainGUI::MainGUI(const YAML::Node& config)
     plot_button_menu->addAction("sweep event density", this, SLOT(sweep_event_density()));
     plot_button_menu->addAction("calc mean scene depth", this, SLOT(calc_mean_scene_depth()));
     plot_button_menu->addAction("plot trajectory in color", this, SLOT(plot_trajectory()));
+    plot_button_menu->addAction("SE(3) pose editor", this, SLOT(show_SE3_pose_editor()));
     ui.plot_button->setMenu(plot_button_menu);
 
     QMenu* minimization_button_menu = new QMenu(this);
@@ -1222,6 +1225,7 @@ void MainGUI::test_general_jacobian()
     jacobi_tester->show();
 
     connect(jacobi_tester, &GeneralJacobiTester::stateHovered, this, &MainGUI::hover_pose);
+    connect(jacobi_tester, &GeneralJacobiTester::stateSelected, this, &MainGUI::select_pose);
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1418,6 +1422,19 @@ void MainGUI::plot_trajectory()
 
     world_renderer->cleanupHiresRendering();
     cout << "done" << endl;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void MainGUI::show_SE3_pose_editor()
+{
+    // no need to delete previous panel, Qt will clean it up
+
+    auto dialog = new SE3PoseEditor(this);
+    dialog->setReferencePose(get_T_WC_selected());
+    dialog->show();
+
+    connect(dialog, &SE3PoseEditor::stateSelected, this, &MainGUI::hover_pose);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/direct_event_camera_tracker/gui/maingui.h
+++ b/direct_event_camera_tracker/gui/maingui.h
@@ -32,6 +32,7 @@
 #include "gui/render_jacobi_tester.h"
 #include "gui/general_jacobi_tester.h"
 #include "gui/evo_map_publisher.h"
+#include "gui/se3_pose_editor.h"
 #include "pyramid.h"
 #include "opengl/world_renderer.h"
 #include "point_yaml.h"
@@ -153,6 +154,7 @@ private slots:
     void sweep_event_density();
     void calc_mean_scene_depth();
     void plot_trajectory();
+    void show_SE3_pose_editor();
 
     void open_evo_map_publisher();
 

--- a/direct_event_camera_tracker/gui/se3_pose_editor.cpp
+++ b/direct_event_camera_tracker/gui/se3_pose_editor.cpp
@@ -1,0 +1,87 @@
+#include "se3_pose_editor.h"
+
+#include <QBoxLayout>
+#include <QPushButton>
+
+using namespace std;
+
+////////////////////////////////////////////////////////////////////////////////
+
+SE3PoseEditor::SE3PoseEditor(
+            QWidget* parent)
+    : QDialog(parent)
+{
+    QVBoxLayout* layout = new QVBoxLayout(this);
+
+    table = new QTableWidget(this);
+    layout->addWidget(table);
+
+    table->setRowCount(6);
+    table->setColumnCount(1);
+
+    table->setVerticalHeaderLabels(get_attr_names());
+
+    for (size_t i = 0; i < 6; ++i) {
+        table->setItem(i, 0, new QTableWidgetItem("0"));
+    }
+
+    connect(table, &QTableWidget::itemChanged, this, &SE3PoseEditor::publishState);
+
+    setLayout(layout);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+QStringList SE3PoseEditor::get_attr_names()
+{
+    QStringList attrs;
+    attrs
+        << "Position X"
+        << "Position Y"
+        << "Position Z"
+        << "Orientation X"
+        << "Orientation Y"
+        << "Orientation Z";
+    return attrs;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+SE3PoseEditor::Vec6 SE3PoseEditor::getTwist()
+{
+    Vec6 v; v <<
+            table->item(0, 0)->text().toDouble(),
+            table->item(1, 0)->text().toDouble(),
+            table->item(2, 0)->text().toDouble(),
+            table->item(3, 0)->text().toDouble(),
+            table->item(4, 0)->text().toDouble(),
+            table->item(5, 0)->text().toDouble();
+    return v;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+Posef SE3PoseEditor::getPose()
+{
+    using Scalar = double;
+
+    Eigen::Transform<Scalar, 3, Eigen::Isometry> T_WC = T_world_ref.T().cast<Scalar>();
+    T_WC *= Sophus::SE3<Scalar>::exp(getTwist()).matrix();
+    return Posef(T_WC);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void SE3PoseEditor::setReferencePose(const Statef& s)
+{
+    T_world_ref = s.pose;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void SE3PoseEditor::publishState()
+{
+    emit stateSelected(Statef(ros::Time(0), getPose()));
+}
+
+////////////////////////////////////////////////////////////////////////////////

--- a/direct_event_camera_tracker/gui/se3_pose_editor.h
+++ b/direct_event_camera_tracker/gui/se3_pose_editor.h
@@ -1,0 +1,37 @@
+#ifndef SE3_POSE_EDITOR_H_GFSAVJFA
+#define SE3_POSE_EDITOR_H_GFSAVJFA
+
+#include <Eigen/Geometry>
+#include <QDialog>
+#include <QTableWidget>
+#include <QTableWidgetItem>
+
+#include "point.h"
+
+class SE3PoseEditor : public QDialog
+{
+    typedef Eigen::Matrix<double,6,1> Vec6;
+
+    Q_OBJECT
+public:
+    SE3PoseEditor(
+            QWidget* parent = 0);
+
+    QStringList get_attr_names();
+
+    Vec6 getTwist();
+    Posef getPose();
+
+public slots:
+    void setReferencePose(const Statef& s);
+    void publishState();
+
+signals:
+    void stateSelected(const Statef& s);
+
+private:
+    QTableWidget* table;
+    Posef T_world_ref;
+};
+
+#endif /* end of include guard: SE3_POSE_EDITOR_H_GFSAVJFA */

--- a/direct_event_camera_tracker/opengl/lib/model.cpp
+++ b/direct_event_camera_tracker/opengl/lib/model.cpp
@@ -194,8 +194,8 @@ void Model::loadMaterialTextures(vector<Texture>& textures, aiMaterial *mat, aiT
             }
         }
 
-        if(!skip)
-        {   // if texture hasn't been loaded already, load it
+        if(!skip) {
+            // if texture hasn't been loaded already, load it
             Texture texture;
             texture.id = TextureFromFile(str.C_Str(), this->directory);
             texture.type = typeName;

--- a/direct_event_camera_tracker/opengl/world_renderer.h
+++ b/direct_event_camera_tracker/opengl/world_renderer.h
@@ -41,6 +41,8 @@ enum MapType {
     CLOUD
 };
 
+std::ostream& operator<<(std::ostream& os, const MapType& map_type);
+
 struct CloudVertex
 {
     Eigen::Vector3f position,

--- a/direct_event_camera_tracker/optimization/opt_analytic.cpp
+++ b/direct_event_camera_tracker/optimization/opt_analytic.cpp
@@ -126,7 +126,7 @@ Scalar OptAnalytic::error(
         throw "Invalid pose for keyframe in forward warp optimization.";
     }
 
-    const Pose<Scalar> T_cam_world = T_world_cam(T_ref_cam.asVector()).inverse();
+    const Pose<Scalar> T_cam_world = T_world_cam_from_T_ref_cam(T_ref_cam.asVector()).inverse();
     const Pose<Scalar> T_world_kf  = params.keyframe.T_WK.pose.cast<Scalar>();
     const Pose<Scalar> T_cam_kf    = T_cam_world * T_world_kf;
 

--- a/direct_event_camera_tracker/optimization/optimization.cpp
+++ b/direct_event_camera_tracker/optimization/optimization.cpp
@@ -60,7 +60,7 @@ void IOptimization::init_optimization(Vector6d& T_ref_cam, Vector6d& V_cam)
 
 Statef IOptimization::finish_optimization(Vector6d& T_ref_cam, Vector6d& V_cam)
 {
-    return Statef(params.initial_state.stamp, Posef(T_world_cam(T_ref_cam)), Motionf(V_cam));
+    return Statef(params.initial_state.stamp, Posef(T_world_cam_from_T_ref_cam(T_ref_cam)), Motionf(V_cam));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -198,19 +198,23 @@ std::unique_ptr<IOptimization> IOptimization::create(const OptParams& params)
 {
     switch (params.method) {
         case OptParams::Method::FORWARD_WARP:
+            //cout << "creating FORWARD_WARP optimizer" << endl;
             return std::make_unique<OptFwdWarp>(params);
 
         case OptParams::Method::RERENDER:
+            //cout << "creating RERENDER optimizer" << endl;
             return std::make_unique<OptRerender>(params);
 
         case OptParams::Method::ANALYTIC:
+            //cout << "creating ANALYTIC optimizer" << endl;
             return std::make_unique<OptAnalytic>(params);
 
         case OptParams::Method::DEBUG:
+            //cout << "creating DEBUG optimizer" << endl;
             return std::make_unique<OptDebug>(params);
 
         default:
-            throw "Invalid optimization method.";
+            throw std::runtime_error("Invalid optimization method.");
     }
 }
 
@@ -222,7 +226,7 @@ ceres::CallbackReturnType OptimizationCallback::operator()(const ceres::Iteratio
 {
     UNUSED(summary);
 
-    Statef state(opt.getParams().initial_state.stamp, Posef(opt.T_world_cam(T_ref_cam)), Motionf(V_cam));
+    Statef state(opt.getParams().initial_state.stamp, Posef(opt.T_world_cam_from_T_ref_cam(T_ref_cam)), Motionf(V_cam));
 
     callback(state);
 

--- a/direct_event_camera_tracker/optimization/optimization.h
+++ b/direct_event_camera_tracker/optimization/optimization.h
@@ -93,10 +93,8 @@ public:
 
     const OptParams& getParams() const { return params; }
 
-    double& state(size_t attr_idx);
-
     template <typename Scalar>
-    Eigen::Transform<Scalar, 3, Eigen::Isometry> T_world_cam(const Eigen::Matrix<Scalar,6,1> T_ref_cam) const
+    Eigen::Transform<Scalar, 3, Eigen::Isometry> T_world_cam_from_T_ref_cam(const Eigen::Matrix<Scalar,6,1> T_ref_cam) const
     {
         Eigen::Transform<Scalar, 3, Eigen::Isometry> T_WC = T_world_ref.T().cast<Scalar>();
         T_WC *= Sophus::SE3<Scalar>::exp(T_ref_cam).matrix();
@@ -157,6 +155,8 @@ public:
     template <typename Scalar>
     bool operator()(const Scalar* const p, const Scalar* const v, Scalar* residual) const
     {
+        // p is 6 dimensional!
+
         Motion<Scalar> pose_rel(p);
         Motion<Scalar> motion(v);
 

--- a/direct_event_camera_tracker/point.h
+++ b/direct_event_camera_tracker/point.h
@@ -280,8 +280,8 @@ template <typename Scalar>
 std::ostream& operator<<(std::ostream& out, const Pose<Scalar>& p)
 {
     out << "  Pose:" << std::endl;
-    out << "\tPosition: " << p.position.vector().transpose() << std::endl;
-    out << "\tOrientation: " << p.orientation.coeffs().transpose() << std::endl;
+    out << "\tPosition: " << std::endl << p.position.vector().transpose() << std::endl;
+    out << "\tOrientation: " << std::endl << p.orientation.coeffs().transpose() << std::endl;
     return out;
 }
 

--- a/direct_event_camera_tracker/utils.cpp
+++ b/direct_event_camera_tracker/utils.cpp
@@ -30,6 +30,10 @@ void image_gradient(const cv::Mat& src, cv::Mat& dst)
 
     Mat grad_x, grad_y;
 
+    #if CV_MAJOR_VERSION >= 4
+    #define CV_SCHARR FILTER_SCHARR
+    #endif
+
     // calculate actual gradient (using a normalized kernel)
     // normalization factor is sum of elements for the smoothing part (16 for SCHARR)
     // times 1/2 for the finite differences due to employing central differences 

--- a/direct_event_camera_tracker/utils/ceres.h
+++ b/direct_event_camera_tracker/utils/ceres.h
@@ -204,7 +204,7 @@ std::ostream& operator<<(std::ostream& os, const Eigen::Matrix<ceres::Jet<T,N>,R
 
     for (size_t r = 0; r < R; r++) {
         os << "\t";
-        for (size_t c = 0; c < R; c++) {
+        for (size_t c = 0; c < C; c++) {
             os << jetV(r,c) << " ";
             //os << "Jet<" << type_name<T>() << ", " << N << ">(" << jet.a << ")";
         }


### PR DESCRIPTION
- Fix Jacobians producing NaN's
- Support for Ubuntu 20.04
- Other small bugfixes

---

Jacobian was sometimes NaN when using ceres autodiff.

It looks like Eigen fails to properly extract the rotation from an Eigen::Transformation (it does SVD which results in NaNs in some situations. Although I haven't been able to reproduce it manually, outside ceres.). Explicitly extracting the rotation matrix and converting it to a Quaternion seems to work though.

Here is an inital pose that resulted in many failed Jacobian entries for the atrium dataset:

```yaml
initial_pose:
  pose:
    rotation:
      x: -0.702945
      y: 0.0738337
      z: -0.10968
      w: 0.698847
    translation:
      z: 1.59201
      y: -9.797739999999999
      x: -0.490413
  motion:
    rotation:
      y: 0.103278
      z: -0.247824
      x: 0.0936916
    velocity:
      z: 0.7058680000000001
      x: -0.632722
      y: 0.143362
  stamp:
    sec: 0
    nsec: 123000000
```